### PR TITLE
Removing zscale, unittest and addressing review comments

### DIFF
--- a/astropy/visualization/lupton_rgb.py
+++ b/astropy/visualization/lupton_rgb.py
@@ -11,7 +11,6 @@ Example usage:
     imageG = np.random.random((100,100))
     imageB = np.random.random((100,100))
     image = lupton_rgb.makeRGB(imageR, imageG, imageB, fileName='randoms.png')
-    lupton_rgb.displayRGB(image)
 """
 
 import numpy as np
@@ -24,6 +23,7 @@ __all__ = ['makeRGB', 'Mapping', 'LinearMapping', 'AsinhMapping',
 
 try:
     import scipy.misc
+    scipy.misc.imresize  # checking if it exists
     HAVE_SCIPY_MISC = True
 except ImportError:
     HAVE_SCIPY_MISC = False
@@ -138,7 +138,7 @@ class Mapping(object):
 
         if size is not None:
             if not HAVE_SCIPY_MISC:
-                raise RuntimeError("Unable to rescale as scipy.misc is unavailable.")
+                raise RuntimeError("Unable to rescale as scipy.misc.imresize is unavailable.")
 
             imageR = scipy.misc.imresize(imageR, size, interp='bilinear', mode='F')
             imageG = scipy.misc.imresize(imageG, size, interp='bilinear', mode='F')

--- a/astropy/visualization/lupton_rgb.py
+++ b/astropy/visualization/lupton_rgb.py
@@ -16,9 +16,9 @@ Example usage:
 
 import numpy as np
 
-__all__ = ['displayRGB', 'makeRGB', 'writeRGB', 'zscale',
-           'Mapping', 'LinearMapping', 'ZScaleMapping', 'AsinhMapping',
-           'AsinhZScaleMapping']
+
+__all__ = ['makeRGB', 'writeRGB', 'Mapping', 'LinearMapping',
+           'AsinhMapping', 'AsinhZScaleMapping']
 
 try:
     import scipy.misc
@@ -463,28 +463,6 @@ def makeRGB(imageR, imageG=None, imageB=None, minimum=0, dataRange=5, Q=8,
         writeRGB(fileName, rgb)
 
     return rgb
-
-
-def displayRGB(rgb, show=True, title=None):
-    """
-    Display an rgb image using matplotlib.
-
-    Parameters
-    ----------
-    rgb : `~numpy.ndarray`
-        The RGB image to display
-    show : bool
-        If true, call `~matplotlib.pyplot.show()`
-    title : str
-        Title to use for the displayed image.
-    """
-    import matplotlib.pyplot as plt
-    plt.imshow(rgb, interpolation='nearest', origin="lower")
-    if title:
-        plt.title(title)
-    if show:
-        plt.show()
-    return plt
 
 
 def writeRGB(fileName, rgbImage):

--- a/astropy/visualization/lupton_rgb.py
+++ b/astropy/visualization/lupton_rgb.py
@@ -17,8 +17,9 @@ Example usage:
 import numpy as np
 
 
-__all__ = ['makeRGB', 'writeRGB', 'Mapping', 'LinearMapping',
-           'AsinhMapping', 'AsinhZScaleMapping']
+__all__ = ['makeRGB', 'Mapping', 'LinearMapping', 'AsinhMapping',
+           'AsinhZScaleMapping']
+
 
 try:
     import scipy.misc
@@ -460,31 +461,7 @@ def makeRGB(imageR, imageG=None, imageB=None, minimum=0, dataRange=5, Q=8,
                                 xSize=xSize, ySize=ySize, rescaleFactor=rescaleFactor)
 
     if fileName:
-        writeRGB(fileName, rgb)
+        import matplotlib.image
+        matplotlib.image.imsave(fileName, rgb)
 
     return rgb
-
-
-def writeRGB(fileName, rgbImage):
-    """
-    Write an RGB image to disk.
-
-    Parameters
-    ----------
-    fileName : str
-        The output file.  The extension defines the format, and must be
-        supported by `~matplotlib.imsave()`.
-    rgbImage : `~numpy.ndarray`
-        The RGB image to save.
-
-    Notes
-    -----
-    Most versions of matplotlib support png and pdf (although the
-    eps/pdf/svg writers may be buggy, possibly due an interaction with
-    useTeX=True in the matplotlib settings).
-
-    If your matplotlib bundles pil/pillow you should also be able to write
-    jpeg and tiff files.
-    """
-    import matplotlib.image
-    matplotlib.image.imsave(fileName, rgbImage)

--- a/astropy/visualization/lupton_rgb.py
+++ b/astropy/visualization/lupton_rgb.py
@@ -41,16 +41,23 @@ def compute_intensity(imageR, imageG=None, imageB=None):
     Parameters
     ----------
     imageR : `~numpy.ndarray`
-        Intensity of image to be mapped to red; or total intensity if imageG and
-        imageB are None.
+        Intensity of image to be mapped to red; or total intensity if ``imageG``
+        and ``imageB`` are None.
     imageG : `~numpy.ndarray`, optional
         Intensity of image to be mapped to green.
     imageB : `~numpy.ndarray`, optional
         Intensity of image to be mapped to blue.
 
+    Returns
+    -------
+    intensity : `~numpy.ndarray`
+        Total intensity from the red, blue and green intensities, or ``imageR``
+        if green and blue images are not provided.
+
     Notes
     -----
-    Inputs may be MaskedImages, Images, or numpy arrays and the return is of the same type.
+    Inputs may be MaskedImages, Images, or numpy arrays and the return is
+    of the same type.
     """
     if imageG is None or imageB is None:
         if not (imageG is None and imageB is None):
@@ -113,6 +120,11 @@ class Mapping(object):
         rescaleFactor : float, optional
             Make size of output image rescaleFactor*size of the input image.
             Cannot be specified if xSize or ySize are given.
+
+        Returns
+        -------
+        RGBimage : `~numpy.ndarray`
+            An image formed by stacking the input images.
         """
         if imageR is None:
             if self._image is None:
@@ -159,6 +171,22 @@ class Mapping(object):
         """
         Return the total intensity from the red, blue, and green intensities.
         This is a naive computation, and may be overridden by subclasses.
+
+        Parameters
+        ----------
+        imageR : `~numpy.ndarray`
+            Intensity of image to be mapped to red; or total intensity if
+            ``imageG`` and ``imageB`` are None.
+        imageG : `~numpy.ndarray`, optional
+            Intensity of image to be mapped to green.
+        imageB : `~numpy.ndarray`, optional
+            Intensity of image to be mapped to blue.
+
+        Returns
+        -------
+        intensity : `~numpy.ndarray`
+            Total intensity from the red, blue and green intensities, or
+            ``imageR`` if green and blue images are not provided.
         """
         return compute_intensity(imageR, imageG, imageB)
 
@@ -169,6 +197,16 @@ class Mapping(object):
 
         The intensity is assumed to have had minimum subtracted (as that can be
         done per-band).
+
+        Parameters
+        ----------
+        I : `~numpy.ndarray`
+            Intensity to be mapped.
+
+        Returns
+        -------
+        mapped_I : `~numpy.ndarray`
+            ``I`` mapped to uint8
         """
         with np.errstate(invalid='ignore', divide='ignore'):  # n.b. np.where can't and doesn't short-circuit
             return np.where(I <= 0, 0, np.where(I < self._uint8Max, I, self._uint8Max))
@@ -404,6 +442,11 @@ def makeRGB(imageR, imageG=None, imageB=None, minimum=0, dataRange=5, Q=8,
     rescaleFactor : float
         Make size of output image rescaleFactor*size of the input image.
         Cannot be specified if xSize or ySize are given.
+
+    Returns
+    -------
+    rgb : `~numpy.ndarray`
+        RGB color image.
     """
     if imageG is None:
         imageG = imageR

--- a/astropy/visualization/tests/test_lupton_rgb.py
+++ b/astropy/visualization/tests/test_lupton_rgb.py
@@ -27,9 +27,6 @@ try:
 except (ImportError, AttributeError):
     HAVE_SCIPY_MISC = False
 
-# set to True to have the finished RGBs displayed on your screen.
-display = False
-
 
 def my_name():
     """Return the name of the current method."""
@@ -172,26 +169,17 @@ class TestLuptonRgb(object):
         asinhMap = lupton_rgb.AsinhMapping(self.min_, self.range_, self.Q)
         rgbImage = asinhMap.makeRgbImage(self.imageR, self.imageG, self.imageB)
 
-        if display:
-            lupton_rgb.displayRGB(rgbImage, title=my_name())
-
     def testStarsAsinhZscale(self):
         """Test creating an RGB image using an asinh stretch estimated using zscale"""
 
         map = lupton_rgb.AsinhZScaleMapping(self.imageR, self.imageG, self.imageB)
         rgbImage = map.makeRgbImage(self.imageR, self.imageG, self.imageB)
 
-        if display:
-            lupton_rgb.displayRGB(rgbImage, title=my_name())
-
     def testStarsAsinhZscaleIntensity(self):
         """Test creating an RGB image using an asinh stretch estimated using zscale on the intensity"""
 
         map = lupton_rgb.AsinhZScaleMapping(self.imageR, self.imageG, self.imageB)
         rgbImage = map.makeRgbImage(self.imageR, self.imageG, self.imageB)
-
-        if display:
-            lupton_rgb.displayRGB(rgbImage, title=my_name())
 
     def testStarsAsinhZscaleIntensityPedestal(self):
         """Test creating an RGB image using an asinh stretch estimated using zscale on the intensity
@@ -205,17 +193,11 @@ class TestLuptonRgb(object):
         map = lupton_rgb.AsinhZScaleMapping(self.imageR, self.imageG, self.imageB, pedestal=pedestal)
         rgbImage = map.makeRgbImage(self.imageR, self.imageG, self.imageB)
 
-        if display:
-            lupton_rgb.displayRGB(rgbImage, title=my_name())
-
     def testStarsAsinhZscaleIntensityBW(self):
         """Test creating a black-and-white image using an asinh stretch estimated
         using zscale on the intensity"""
 
         rgbImage = lupton_rgb.AsinhZScaleMapping(self.imageR).makeRgbImage()
-
-        if display:
-            lupton_rgb.displayRGB(rgbImage, title=my_name())
 
     def testMakeRGB(self):
         """Test the function that does it all"""
@@ -242,9 +224,6 @@ class TestLuptonRgb(object):
 
         rgbImage = lupton_rgb.LinearMapping(-8.45, 13.44).makeRgbImage(self.imageR)
 
-        if display:
-            lupton_rgb.displayRGB(rgbImage, title=my_name())
-
     def testLinearMinMax(self):
         """Test using a min/max linear stretch
 
@@ -253,16 +232,10 @@ class TestLuptonRgb(object):
 
         rgbImage = lupton_rgb.LinearMapping(image=self.imageR).makeRgbImage()
 
-        if display:
-            lupton_rgb.displayRGB(rgbImage, title=my_name())
-
     def testZScale(self):
         """Test using a zscale stretch"""
 
         rgbImage = lupton_rgb.ZScaleMapping(self.imageR).makeRgbImage()
-
-        if display:
-            lupton_rgb.displayRGB(rgbImage, title=my_name())
 
     def testWriteStars(self):
         """Test writing RGB files to disk"""
@@ -296,9 +269,6 @@ class TestLuptonRgb(object):
         asinhMap = lupton_rgb.AsinhMapping(self.min_, self.range_, self.Q)
         rgbImage = asinhMap.makeRgbImage(self.imageR, self.imageG, self.imageB)
 
-        if display:
-            lupton_rgb.displayRGB(rgbImage, title=my_name())
-
     @pytest.mark.skipif('not HAVE_SCIPY_MISC', reason="Resizing images requires scipy.misc")
     def testStarsResizeToSize(self):
         """Test creating an RGB image of a specified size"""
@@ -307,9 +277,6 @@ class TestLuptonRgb(object):
         ySize = self.imageR.shape[1]/2
         asinhZ = lupton_rgb.AsinhZScaleMapping(self.imageR)
         rgbImage = asinhZ.makeRgbImage(self.imageR, self.imageG, self.imageB, xSize=xSize, ySize=ySize)
-
-        if display:
-            lupton_rgb.displayRGB(rgbImage, title=my_name())
 
     @pytest.mark.skipif('not HAVE_SCIPY_MISC', reason="Resizing images requires scipy.misc")
     def testStarsResizeToSize_uint(self):
@@ -322,9 +289,6 @@ class TestLuptonRgb(object):
         imageB = np.array(self.imageB, dtype=np.uint16)
         asinhZ = lupton_rgb.AsinhZScaleMapping(imageR)
         rgbImage = asinhZ.makeRgbImage(imageR, imageG, imageB, xSize=xSize, ySize=ySize)
-
-        if display:
-            lupton_rgb.displayRGB(rgbImage, title=my_name())
 
     def _testStarsResizeSpecifications(self, xSize=None, ySize=None, frac=None):
         """Test creating an RGB image changing the output """
@@ -343,9 +307,6 @@ class TestLuptonRgb(object):
         if frac is not None:
             assert int(frac*self.imageR.shape[1]) == w
             assert int(frac*self.imageR.shape[0]) == h
-
-        if display:
-            lupton_rgb.displayRGB(rgbImage, title=my_name())
 
     @pytest.mark.skipif('not HAVE_SCIPY_MISC', reason="Resizing images requires scipy.misc")
     def testStarsResizeSpecificaions_xSize_ySize(self):

--- a/astropy/visualization/tests/test_lupton_rgb.py
+++ b/astropy/visualization/tests/test_lupton_rgb.py
@@ -228,12 +228,12 @@ class TestLuptonRgb(unittest.TestCase):
             green = saturate(self.imageG, satValue)
             blue = saturate(self.imageB, satValue)
             lupton_rgb.makeRGB(red, green, blue, self.min, self.range, self.Q, fileName=temp)
-            self.assertTrue(os.path.exists(temp.name))
+            assert os.path.exists(temp.name)
 
     def testMakeRGB_saturated_fix(self):
         satValue = 1000.0
         # TODO: Cannot test with these options yet, as that part of the code is not implemented.
-        with self.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             red = saturate(self.imageR, satValue)
             green = saturate(self.imageG, satValue)
             blue = saturate(self.imageB, satValue)
@@ -273,7 +273,7 @@ class TestLuptonRgb(unittest.TestCase):
         rgbImage = asinhMap.makeRgbImage(self.imageR, self.imageG, self.imageB)
         with tempfile.NamedTemporaryFile(suffix=".png") as temp:
             lupton_rgb.writeRGB(temp, rgbImage)
-            self.assertTrue(os.path.exists(temp.name))
+            assert os.path.exists(temp.name)
 
     def testSaturated(self):
         """Test interpolating saturated pixels"""
@@ -286,9 +286,9 @@ class TestLuptonRgb(unittest.TestCase):
 
         lupton_rgb.replaceSaturatedPixels(self.imageR, self.imageG, self.imageB, 1, 2000)
         # Check that we replaced those NaNs with some reasonable value
-        self.assertTrue(np.isfinite(self.imageR.getImage().getArray()).all())
-        self.assertTrue(np.isfinite(self.imageG.getImage().getArray()).all())
-        self.assertTrue(np.isfinite(self.imageB.getImage().getArray()).all())
+        assert np.isfinite(self.imageR.getImage().getArray()).all()
+        assert np.isfinite(self.imageG.getImage().getArray()).all()
+        assert np.isfinite(self.imageB.getImage().getArray()).all()
 
         # Prepare for generating an output file
         # TBD: FROMAFW
@@ -340,12 +340,12 @@ class TestLuptonRgb(unittest.TestCase):
         # afw and numpy have different conventions!
         h, w, _ = rgbImage.shape
         if xSize is not None:
-            self.assertEqual(int(xSize), w)
+            assert int(xSize) == w
         if ySize is not None:
-            self.assertEqual(int(ySize), h)
+            assert int(ySize) == h
         if frac is not None:
-            self.assertEqual(int(frac*self.imageR.shape[1]), w)
-            self.assertEqual(int(frac*self.imageR.shape[0]), h)
+            assert int(frac*self.imageR.shape[1]) == w
+            assert int(frac*self.imageR.shape[0]) == h
 
         if display:
             lupton_rgb.displayRGB(rgbImage, title=my_name())
@@ -381,4 +381,4 @@ class TestLuptonRgb(unittest.TestCase):
 
         with tempfile.NamedTemporaryFile(suffix=".png") as temp:
             lupton_rgb.makeRGB(self.imageR, self.imageG, self.imageB, fileName=temp, rescaleFactor=0.5)
-            self.assertTrue(os.path.exists(temp.name))
+            assert os.path.exists(temp.name)

--- a/astropy/visualization/tests/test_lupton_rgb.py
+++ b/astropy/visualization/tests/test_lupton_rgb.py
@@ -17,8 +17,12 @@ from ...convolution import convolve, Gaussian2DKernel
 from ...tests.helper import pytest
 from .. import lupton_rgb
 
-import matplotlib
-matplotlib.use('TkAgg')
+try:
+    import matplotlib
+    matplotlib.use('TkAgg')
+    HAS_MATPLOTLIB = True
+except ImportError:
+    HAS_MATPLOTLIB = False
 
 try:
     import scipy.misc
@@ -199,6 +203,7 @@ class TestLuptonRgb(object):
 
         rgbImage = lupton_rgb.AsinhZScaleMapping(self.imageR).makeRgbImage()
 
+    @pytest.mark.skipif('not HAS_MATPLOTLIB')
     def testMakeRGB(self):
         """Test the function that does it all"""
         satValue = 1000.0
@@ -332,6 +337,7 @@ class TestLuptonRgb(object):
     def testStarsResizeSpecifications_frac_twice(self):
         self._testStarsResizeSpecifications(frac=2)
 
+    @pytest.mark.skipif('not HAS_MATPLOTLIB')
     @pytest.mark.skipif('not HAVE_SCIPY_MISC', reason="Resizing images requires scipy.misc")
     def testMakeRGBResize(self):
         """Test the function that does it all, including rescaling"""

--- a/astropy/visualization/tests/test_lupton_rgb.py
+++ b/astropy/visualization/tests/test_lupton_rgb.py
@@ -15,6 +15,7 @@ import numpy as np
 from numpy.testing import assert_equal
 
 from ...convolution import convolve, Gaussian2DKernel
+from ...tests.helper import pytest
 from .. import lupton_rgb
 
 import matplotlib
@@ -274,9 +275,9 @@ class TestLuptonRgb(unittest.TestCase):
             lupton_rgb.writeRGB(temp, rgbImage)
             self.assertTrue(os.path.exists(temp.name))
 
-    @unittest.skip('replaceSaturatedPixels is not implemented in astropy yet')
     def testSaturated(self):
         """Test interpolating saturated pixels"""
+        pytest.skip('replaceSaturatedPixels is not implemented in astropy yet')
 
         satValue = 1000.0
         self.imageR = saturate(self.imageR, satValue)
@@ -301,7 +302,7 @@ class TestLuptonRgb(unittest.TestCase):
         if display:
             lupton_rgb.displayRGB(rgbImage, title=my_name())
 
-    @unittest.skipUnless(HAVE_SCIPY_MISC, "Resizing images requires scipy.misc")
+    @pytest.mark.skipif('not HAVE_SCIPY_MISC', "Resizing images requires scipy.misc")
     def testStarsResizeToSize(self):
         """Test creating an RGB image of a specified size"""
 
@@ -313,7 +314,7 @@ class TestLuptonRgb(unittest.TestCase):
         if display:
             lupton_rgb.displayRGB(rgbImage, title=my_name())
 
-    @unittest.skipUnless(HAVE_SCIPY_MISC, "Resizing images requires scipy.misc")
+    @pytest.mark.skipif('not HAVE_SCIPY_MISC', "Resizing images requires scipy.misc")
     def testStarsResizeToSize_uint(self):
         """Test creating an RGB image of a specified size"""
 
@@ -349,31 +350,31 @@ class TestLuptonRgb(unittest.TestCase):
         if display:
             lupton_rgb.displayRGB(rgbImage, title=my_name())
 
-    @unittest.skipUnless(HAVE_SCIPY_MISC, "Resizing images requires scipy.misc")
+    @pytest.mark.skipif('not HAVE_SCIPY_MISC', "Resizing images requires scipy.misc")
     def testStarsResizeSpecificaions_xSize_ySize(self):
         self._testStarsResizeSpecifications(xSize=self.imageR.shape[0]/2, ySize=self.imageR.shape[1]/2)
 
-    @unittest.skipUnless(HAVE_SCIPY_MISC, "Resizing images requires scipy.misc")
+    @pytest.mark.skipif('not HAVE_SCIPY_MISC', "Resizing images requires scipy.misc")
     def testStarsResizeSpecifications_twice_xSize(self):
         self._testStarsResizeSpecifications(xSize=2*self.imageR.shape[0])
 
-    @unittest.skipUnless(HAVE_SCIPY_MISC, "Resizing images requires scipy.misc")
+    @pytest.mark.skipif('not HAVE_SCIPY_MISC', "Resizing images requires scipy.misc")
     def testStarsResizeSpecifications_half_xSize(self):
         self._testStarsResizeSpecifications(xSize=self.imageR.shape[0]/2)
 
-    @unittest.skipUnless(HAVE_SCIPY_MISC, "Resizing images requires scipy.misc")
+    @pytest.mark.skipif('not HAVE_SCIPY_MISC', "Resizing images requires scipy.misc")
     def testStarsResizeSpecifications_half_ySize(self):
         self._testStarsResizeSpecifications(ySize=self.imageR.shape[0]/2)
 
-    @unittest.skipUnless(HAVE_SCIPY_MISC, "Resizing images requires scipy.misc")
+    @pytest.mark.skipif('not HAVE_SCIPY_MISC', "Resizing images requires scipy.misc")
     def testStarsResizeSpecifications_frac_half(self):
         self._testStarsResizeSpecifications(frac=0.5)
 
-    @unittest.skipUnless(HAVE_SCIPY_MISC, "Resizing images requires scipy.misc")
+    @pytest.mark.skipif('not HAVE_SCIPY_MISC', "Resizing images requires scipy.misc")
     def testStarsResizeSpecifications_frac_twice(self):
         self._testStarsResizeSpecifications(frac=2)
 
-    @unittest.skipUnless(HAVE_SCIPY_MISC, "Resizing images requires scipy.misc")
+    @pytest.mark.skipif('not HAVE_SCIPY_MISC', "Resizing images requires scipy.misc")
     def testMakeRGBResize(self):
         """Test the function that does it all, including rescaling"""
         lupton_rgb.makeRGB(self.imageR, self.imageG, self.imageB, xSize=40, ySize=60)

--- a/astropy/visualization/tests/test_lupton_rgb.py
+++ b/astropy/visualization/tests/test_lupton_rgb.py
@@ -237,10 +237,6 @@ class TestLuptonRgb(object):
 
         rgbImage = lupton_rgb.LinearMapping(image=self.imageR).makeRgbImage()
 
-    def testZScale(self):
-        """Test using a zscale stretch"""
-
-        rgbImage = lupton_rgb.ZScaleMapping(self.imageR).makeRgbImage()
 
     @pytest.mark.skipif('not HAS_MATPLOTLIB')
     def testWriteStars(self):

--- a/astropy/visualization/tests/test_lupton_rgb.py
+++ b/astropy/visualization/tests/test_lupton_rgb.py
@@ -242,12 +242,13 @@ class TestLuptonRgb(object):
 
         rgbImage = lupton_rgb.ZScaleMapping(self.imageR).makeRgbImage()
 
+    @pytest.mark.skipif('not HAS_MATPLOTLIB')
     def testWriteStars(self):
         """Test writing RGB files to disk"""
         asinhMap = lupton_rgb.AsinhMapping(self.min_, self.range_, self.Q)
-        rgbImage = asinhMap.makeRgbImage(self.imageR, self.imageG, self.imageB)
         with tempfile.NamedTemporaryFile(suffix=".png") as temp:
-            lupton_rgb.writeRGB(temp, rgbImage)
+            rgbImage = asinhMap.makeRgbImage(self.imageR, self.imageG,
+                                             self.imageB, fileName=temp)
             assert os.path.exists(temp.name)
 
     def testSaturated(self):

--- a/astropy/visualization/tests/test_lupton_rgb.py
+++ b/astropy/visualization/tests/test_lupton_rgb.py
@@ -237,16 +237,6 @@ class TestLuptonRgb(object):
 
         rgbImage = lupton_rgb.LinearMapping(image=self.imageR).makeRgbImage()
 
-
-    @pytest.mark.skipif('not HAS_MATPLOTLIB')
-    def testWriteStars(self):
-        """Test writing RGB files to disk"""
-        asinhMap = lupton_rgb.AsinhMapping(self.min_, self.range_, self.Q)
-        with tempfile.NamedTemporaryFile(suffix=".png") as temp:
-            rgbImage = asinhMap.makeRgbImage(self.imageR, self.imageG,
-                                             self.imageB, fileName=temp)
-            assert os.path.exists(temp.name)
-
     def testSaturated(self):
         """Test interpolating saturated pixels"""
         pytest.skip('replaceSaturatedPixels is not implemented in astropy yet')

--- a/astropy/visualization/tests/test_lupton_rgb.py
+++ b/astropy/visualization/tests/test_lupton_rgb.py
@@ -4,7 +4,7 @@
 Tests for RGB Images
 """
 
-from __future__ import division, print_function
+from __future__ import absolute_import, division
 
 import sys
 import os


### PR DESCRIPTION
 * [x] - clean up tests, transform unittest to pure pytest
 * [x] use astropy zscale
 * [x] making mpl optional dependency for tests, etc
 * [x] remove ``writeRGB`` and ``displayRGB`` as @cdeil suggested
 * [x] adding Returns to the docstring
 * some small additional improvements